### PR TITLE
도서 목록 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Error from "./components/common/Error";
 import Signup from "./pages/Signup";
 import ResetPassword from "./pages/ResetPassword";
 import Login from "./pages/Login";
+import Books from "./pages/Books";
 
 const router = createBrowserRouter([
   {
@@ -15,7 +16,7 @@ const router = createBrowserRouter([
   },
   {
     path: "/books",
-    element: <Layout><div>도서 목록</div></Layout>
+    element: <Layout><Books /></Layout>
   },
   {
     path: "/signup",

--- a/src/api/books.api.ts
+++ b/src/api/books.api.ts
@@ -1,0 +1,30 @@
+import { Book } from "../models/book.model";
+import { Pagination } from "../models/pagination.model";
+import { httpClient } from "./http";
+
+interface FetchBooksParams {
+    categoryId?: number;
+    recent?: boolean;
+    limit: number;
+    page: number;
+}
+
+interface FetchBooksResponse {
+    books: Book[];
+    pagination: Pagination;
+}
+
+export const fetchBooks = async (params: FetchBooksParams) => {
+    try {
+        const response = await httpClient.get<FetchBooksResponse>("/books", { params });
+        return response.data;
+    } catch (error) {
+        return {
+            books: [],
+            pagination: {
+                currentPage: 1,
+                totalCount: 0
+            }
+        }
+    }
+};

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -5,13 +5,19 @@ const BASE_URL = "http://localhost:7777/api";
 const DEFAULT_TIMEOUT = 30000;
 
 export const createClient = (config?: AxiosRequestConfig) => {
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+    }
+
+    const token = getToken();
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
     const axiosInstance = axios.create({
         baseURL: BASE_URL,
         timeout: DEFAULT_TIMEOUT,
-        headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${getToken() ?? ""}`
-        },
+        headers,
         withCredentials: true,
         ...config
     });
@@ -24,7 +30,7 @@ export const createClient = (config?: AxiosRequestConfig) => {
                 window.location.href = "/login";
                 return;
             }
-            Promise.reject(error);
+            // Promise.reject(error);
         }
     );
 

--- a/src/components/books/BookItem.spec.tsx
+++ b/src/components/books/BookItem.spec.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable testing-library/no-node-access */
+import { render, screen } from '@testing-library/react';
+import { BookStoreThemeProvider } from '../../context/themeContext';
+import BookItem from './BookItem';
+import { Book } from '../../models/book.model';
+
+const dummyBook: Book = {
+    id: 1,
+    title: "Dummy Book",
+    imageId: 5,
+    summary: "Dummy Summary",
+    author: "Dummy Author",
+    price: 20000,
+    likes: 1,
+    liked: false,
+    publishedDate: "2023-04-10"
+};
+
+describe("BookItem 컴포넌트 테스트", () => {
+    it("렌더 확인", () => {
+        render(
+            <BookStoreThemeProvider>
+                <BookItem book={dummyBook} />
+            </BookStoreThemeProvider>
+        );
+
+        expect(screen.getByText(dummyBook.title)).toBeInTheDocument();
+        expect(screen.getByText(dummyBook.summary)).toBeInTheDocument();
+        expect(screen.getByText(dummyBook.author)).toBeInTheDocument();
+        expect(screen.getByText("20,000원")).toBeInTheDocument();
+        expect(screen.getByText(dummyBook.likes)).toBeInTheDocument();
+        expect(screen.getByAltText(dummyBook.title)).toHaveAttribute("src", `https://picsum.photos/id/${dummyBook.imageId}/300/300`);
+    });
+});

--- a/src/components/books/BookItem.tsx
+++ b/src/components/books/BookItem.tsx
@@ -1,0 +1,94 @@
+import styled from 'styled-components';
+import { Book } from '../../models/book.model';
+import { getImgSrc } from '../../utils/image';
+import { formatNumber } from '../../utils/format';
+import { FaHeart } from 'react-icons/fa';
+import { ViewMode } from './BooksViewSwitcher';
+
+interface Props {
+    book: Book;
+    view?: ViewMode;
+}
+
+function BookItem({ book, view }: Props) {
+    return (
+        <BookItemStyle view={view}>
+            <div className="img">
+                <img src={getImgSrc(book.imageId)} alt={book.title} />
+            </div>
+            <div className="content">
+                <h2 className="title">{book.title}</h2>
+                <p className="summary">{book.summary}</p>
+                <p className="author">{book.author}</p>
+                <p className="price">{formatNumber(book.price)}원</p>
+                <div className="likes">
+                    <FaHeart />
+                    <span>{book.likes}</span>
+                </div>
+            </div>
+        </BookItemStyle>
+    );
+}
+
+const BookItemStyle = styled.div<Pick<Props, "view">>`
+    display: flex;
+    flex-direction: ${({ view }) => view === "grid" ? "column" : "row"};;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+
+    .img {
+        border-radius: ${({ theme }) => theme.borderRadius.default};
+        overflow: hidden;
+        width: ${({ view }) => view === "grid" ? "auto" : "160px"};
+        img {
+            max-width: 100%;
+        }
+    }
+
+    .content {
+        padding: 16px;
+        position: relative;
+        flex: ${({ view }) => view === "grid" ? 0 : 1};
+        .title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin: 0 0 12px 0;
+        }
+        .summary {
+            font-size: 0.875rem;
+            color: ${({ theme }) => theme.color.secondary};
+            margin: 0 0 4px 0;
+        }
+        .author {
+            font-size: 0.875rem;
+            color: ${({ theme }) => theme.color.secondary};
+            margin: 0 0 4px 0;
+        }
+        .price {
+            font-size: 1rem;
+            color: ${({ theme }) => theme.color.secondary};
+            margin: 0 0 4px 0;
+            font-weight: 700;
+        }
+        .likes {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 0.875rem;
+            color: ${({ theme }) => theme.color.secondary};
+            margin: 0 0 4px 0;
+            font-weight: 700;
+            border: 1px solid ${({ theme }) => theme.color.border};
+            border-radius: ${({ theme }) => theme.borderRadius.default};
+            padding: 4px 12px;
+            position: absolute;
+            bottom: 16px;
+            right: 16px;
+
+            svg {
+                color: ${({ theme }) => theme.color.primary};
+            }
+        }
+    }
+`;
+
+export default BookItem;

--- a/src/components/books/BooksEmpty.tsx
+++ b/src/components/books/BooksEmpty.tsx
@@ -1,0 +1,38 @@
+import { FaSmileWink } from 'react-icons/fa';
+import styled from 'styled-components';
+import Title from '../common/Title';
+import { Link } from 'react-router-dom';
+
+function BooksEmpty() {
+    return (
+        <BooksEmptyStyle>
+            <div className="icon">
+                <FaSmileWink />
+            </div>
+            <Title size="large" color="secondary">
+                검색 결과가 없습니다.
+            </Title>
+            <p>
+                <Link to="/books">전체 검색 결과로 이동</Link>
+            </p>
+        </BooksEmptyStyle>
+    );
+}
+
+const BooksEmptyStyle = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    padding: 120px 0;
+
+    .icon {
+        svg {
+            font-size: 4rem;
+            fill: #ccc;
+        }
+    }
+`;
+
+export default BooksEmpty;

--- a/src/components/books/BooksFilter.tsx
+++ b/src/components/books/BooksFilter.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { useCategory } from '../../hooks/useCategory';
+import Button from '../common/Button';
+import { useSearchParams } from 'react-router-dom';
+import { QUERYSTRING } from '../../constants/querystrings';
+
+function BooksFilter() {
+    const { category } = useCategory();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const handleCategory = (id: number | null) => {
+        const newSearchParams = new URLSearchParams(searchParams);
+
+        if (id === null) {
+            newSearchParams.delete(QUERYSTRING.CATEGORY_ID);
+        } else {
+            newSearchParams.set(QUERYSTRING.CATEGORY_ID, id.toString());
+        }
+
+        setSearchParams(newSearchParams);
+    };
+
+    const handleNews = () => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        if (newSearchParams.get(QUERYSTRING.RECENT)) {
+            newSearchParams.delete(QUERYSTRING.RECENT);
+        } else {
+            newSearchParams.set(QUERYSTRING.RECENT, "true");
+        }
+
+        setSearchParams(newSearchParams);
+    };
+
+    return (
+        <BooksFilterStyle>
+            <div className="category">
+                {
+                    category.map(item => (
+                        <Button
+                            key={item.id}
+                            size="medium"
+                            scheme={item.isActive ? "primary" : "normal"}
+                            onClick={() => handleCategory(item.id)}>
+                            {item.name}
+                        </Button>
+                    ))
+                }
+            </div>
+            <div className="recent">
+                <Button size="medium" scheme={searchParams.get(QUERYSTRING.RECENT) ? "primary" : "normal"} onClick={handleNews}>신간</Button>
+            </div>
+        </BooksFilterStyle>
+    );
+}
+
+const BooksFilterStyle = styled.div`
+    display: flex;
+    gap: 24px;
+
+    .category {
+        display: flex;
+        gap: 8px;
+    }
+`;
+
+export default BooksFilter;

--- a/src/components/books/BooksList.tsx
+++ b/src/components/books/BooksList.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import BookItem from './BookItem';
+import { Book } from '../../models/book.model';
+import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { QUERYSTRING } from '../../constants/querystrings';
+import { ViewMode } from './BooksViewSwitcher';
+
+interface Props {
+    books: Book[];
+}
+
+function BooksList({ books }: Props) {
+    const [view, setView] = useState<ViewMode>("grid");
+    const location = useLocation();
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        if (params.get(QUERYSTRING.VIEW)) {
+            setView(params.get(QUERYSTRING.VIEW) as ViewMode);
+        }
+    }, [location.search]);
+
+    return (
+        <BooksListStyle view={view}>
+            {
+                books?.map(book => (
+                    <BookItem key={book.id} book={book} view={view} />
+                ))
+            }
+        </BooksListStyle>
+    );
+}
+
+interface BooksListStyleProps {
+    view: ViewMode;
+}
+
+const BooksListStyle = styled.div<BooksListStyleProps>`
+    display: grid;
+    grid-template-columns: ${({ view }) => view === "grid" ? "repeat(4, 1fr)" : "repeat(1, 1fr)"};
+    gap: 24px;
+`;
+
+export default BooksList;

--- a/src/components/books/BooksViewSwitcher.tsx
+++ b/src/components/books/BooksViewSwitcher.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+import Button from '../common/Button';
+import { FaList, FaTh } from 'react-icons/fa';
+import { useSearchParams } from 'react-router-dom';
+import { QUERYSTRING } from '../../constants/querystrings';
+import { useEffect } from 'react';
+
+const viewOptions = [
+    {
+        value: "list",
+        icon: <FaList />
+    },
+    {
+        value: "grid",
+        icon: <FaTh />
+    }
+];
+
+export type ViewMode = "grid" | "list";
+
+function BooksViewSwitcher() {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const handleSwitch = (value: ViewMode) => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set(QUERYSTRING.VIEW, value);
+        setSearchParams(newSearchParams);
+    };
+
+    useEffect(() => {
+        if (!searchParams.get(QUERYSTRING.VIEW)) {
+            handleSwitch("grid");
+        }
+    }, []);
+
+    return (
+        <BooksViewSwitcherStyle>
+            {
+                viewOptions.map(({ value, icon }) => (
+                    <Button
+                        key={value}
+                        size="medium"
+                        scheme={searchParams.get(QUERYSTRING.VIEW) === value ? "primary" : "normal"}
+                        onClick={() => handleSwitch(value as ViewMode)}>
+                        {icon}
+                    </Button>
+                ))
+            }
+        </BooksViewSwitcherStyle>
+    );
+}
+
+const BooksViewSwitcherStyle = styled.div`
+    display: flex;
+    gap: 8px;
+
+    svg {
+        fill: white;
+    }
+`;
+
+export default BooksViewSwitcher;

--- a/src/components/books/Pagination.tsx
+++ b/src/components/books/Pagination.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import { Pagination as IPagination } from '../../models/pagination.model';
+import Button from '../common/Button';
+import { LIMIT } from '../../constants/pagination';
+import { useSearchParams } from 'react-router-dom';
+import { QUERYSTRING } from '../../constants/querystrings';
+
+interface Props {
+    pagination: IPagination;
+}
+
+function Pagination({ pagination }: Props) {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const { currentPage, totalCount } = pagination;
+    const pages: number = Math.ceil(totalCount / LIMIT);
+
+    const handleClickPage = (page: number) => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set(QUERYSTRING.PAGE, page.toString());
+        setSearchParams(newSearchParams);
+    };
+
+    return (
+        <PaginationStyle>
+            {
+                pages > 0 && (
+                    <ol>
+                        {
+                            Array(pages).fill(0).map((_, i) => (
+                                <li>
+                                    <Button
+                                        key={i}
+                                        size="small"
+                                        scheme={i + 1 === currentPage ? "primary" : "normal"}
+                                        onClick={() => handleClickPage(i + 1)}>
+                                        {i + 1}
+                                    </Button>
+                                </li>
+                            ))
+                        }
+                    </ol>
+                )
+            }
+        </PaginationStyle>
+    );
+}
+
+const PaginationStyle = styled.div`
+    display: flex;
+    justify-content: start;
+    align-items: center;
+    padding: 24px 0;
+
+    ol {
+        list-style: none;
+        display: flex;
+        gap: 8px;
+        padding: 0;
+        margin: 0;
+    }
+`;
+
+export default Pagination;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -9,9 +9,9 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     isLoading?: boolean;
 }
 
-function Button({ children, size, scheme, disabled, isLoading }: Props) {
+function Button({ children, size, scheme, disabled, isLoading, ...props }: Props) {
     return (
-        <ButtonStyle size={size} scheme={scheme} disabled={disabled} isLoading={isLoading}>
+        <ButtonStyle size={size} scheme={scheme} disabled={disabled} isLoading={isLoading} {...props}>
             {children}
         </ButtonStyle>
     );

--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -1,0 +1,1 @@
+export const LIMIT = 8;

--- a/src/constants/querystrings.ts
+++ b/src/constants/querystrings.ts
@@ -1,0 +1,6 @@
+export const QUERYSTRING = {
+    CATEGORY_ID: "categoryId",
+    RECENT: "recent",
+    PAGE: "page",
+    VIEW: "view"
+};

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,0 +1,35 @@
+import { useLocation } from "react-router-dom";
+import { Book } from "../models/book.model";
+import { useEffect, useState } from "react";
+import { Pagination } from "../models/pagination.model";
+import { QUERYSTRING } from "../constants/querystrings";
+import { fetchBooks } from "../api/books.api";
+import { LIMIT } from "../constants/pagination";
+
+export const useBooks = () => {
+    const location = useLocation();
+
+    const [books, setBooks] = useState<Book[]>([]);
+    const [pagination, setPagination] = useState<Pagination>({
+        currentPage: 1,
+        totalCount: 0
+    });
+    const [isEmpty, setIsEmpty] = useState(true);
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+
+        fetchBooks({
+            categoryId: params.get(QUERYSTRING.CATEGORY_ID) ? Number(params.get(QUERYSTRING.CATEGORY_ID)) : undefined,
+            recent: params.get(QUERYSTRING.RECENT) ? true : undefined,
+            limit: LIMIT,
+            page: params.get(QUERYSTRING.PAGE) ? Number(params.get(QUERYSTRING.PAGE)) : 1,
+        }).then(({ books, pagination }) => {
+            setBooks(books);
+            setPagination(pagination);
+            setIsEmpty(books.length === 0);
+        })
+    }, [location.search]);
+
+    return { books, pagination, isEmpty };
+};

--- a/src/hooks/useCategory.ts
+++ b/src/hooks/useCategory.ts
@@ -1,9 +1,26 @@
 import { useEffect, useState } from "react";
 import { Category } from "../models/category.model";
 import { fetchCategory } from "../api/category.api";
+import { useLocation } from "react-router-dom";
+import { QUERYSTRING } from "../constants/querystrings";
 
 export const useCategory = () => {
+    const location = useLocation();
     const [category, setCategory] = useState<Category[]>([]);
+
+    const setActive = () => {
+        const params = new URLSearchParams(location.search);
+        setCategory((prev) => {
+            return prev.map(item => {
+                return {
+                    ...item,
+                    isActive: params.get(QUERYSTRING.CATEGORY_ID)
+                        ? item.id === Number(params.get(QUERYSTRING.CATEGORY_ID))
+                        : item.id === null
+                }
+            })
+        });
+    };
 
     useEffect(() => {
         fetchCategory()
@@ -19,8 +36,13 @@ export const useCategory = () => {
                 ];
 
                 setCategory(categoryWithAll);
+                setActive();
             });
     }, []);
+
+    useEffect(() => {
+        setActive();
+    }, [location.search]);
 
     return { category };
 };

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,4 +1,5 @@
 export interface Category {
     id: number | null;
     name: string;
+    isActive?: boolean;
 }

--- a/src/pages/Books.tsx
+++ b/src/pages/Books.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import Title from '../components/common/Title';
+import BooksFilter from '../components/books/BooksFilter';
+import BooksList from '../components/books/BooksList';
+import BooksEmpty from '../components/books/BooksEmpty';
+import Pagination from '../components/books/Pagination';
+import BooksViewSwitcher from '../components/books/BooksViewSwitcher';
+import { useBooks } from '../hooks/useBooks';
+
+function Books() {
+    const { books, pagination, isEmpty } = useBooks();
+
+    console.log(books);
+    console.log(pagination);
+    return (
+        <>
+            <Title size="large">도서 검색 결과</Title>
+            <BooksStyle>
+                <div className="filter">
+                    <BooksFilter />
+                    <BooksViewSwitcher />
+                </div>
+                {!isEmpty && <BooksList books={books} />}
+                {isEmpty && <BooksEmpty />}
+                {!isEmpty && <Pagination pagination={pagination} />}
+            </BooksStyle>
+        </>
+    );
+}
+
+const BooksStyle = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 24px;
+
+    .filter {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 20px 0;
+    }
+`;
+
+export default Books;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,3 @@
+export const getImgSrc = (id: number) => {
+    return `https://picsum.photos/id/${id}/300/300`;
+};


### PR DESCRIPTION
# 도서 목록 페이지
1. 도서 목록을 fetch하여 화면에 렌더
2. 페이지네이션 구현
3. 검색 결과가 없을 때, 결과 없음 화면 노출
4. 카테고리 및 신간 필터 기능 제공
5. 목록의 view는 그리드/목록 형태로 변경 가능