### PR TITLE
장바구니 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import ResetPassword from "./pages/ResetPassword";
 import Login from "./pages/Login";
 import Books from "./pages/Books";
 import BookDetail from "./pages/BookDetail";
+import Cart from "./pages/Cart";
+import Order from "./pages/Order";
 
 const router = createBrowserRouter([
   {
@@ -34,6 +36,14 @@ const router = createBrowserRouter([
   {
     path: "/books/:bookId",
     element: <Layout><BookDetail /></Layout>
+  },
+  {
+    path: "/cart",
+    element: <Layout><Cart /></Layout>
+  },
+  {
+    path: "/order",
+    element: <Layout><Order /></Layout>
   },
 ]);
 

--- a/src/api/carts.api.ts
+++ b/src/api/carts.api.ts
@@ -1,3 +1,4 @@
+import { Cart } from "../models/cart.model";
 import { httpClient } from "./http";
 
 interface AddCartParams {
@@ -7,5 +8,15 @@ interface AddCartParams {
 
 export const addCart = async (params: AddCartParams) => {
     const response = await httpClient.post("/cart", params);
+    return response.data;
+};
+
+export const fetchCart = async () => {
+    const response = await httpClient.get<Cart[]>("/cart");
+    return response.data;
+};
+
+export const deleteCart = async (itemId: number) => {
+    const response = await httpClient.delete(`/cart/${itemId}`);
     return response.data;
 };

--- a/src/components/books/BooksEmpty.tsx
+++ b/src/components/books/BooksEmpty.tsx
@@ -1,38 +1,15 @@
 import { FaSmileWink } from 'react-icons/fa';
-import styled from 'styled-components';
-import Title from '../common/Title';
 import { Link } from 'react-router-dom';
+import Empty from '../common/Empty';
 
 function BooksEmpty() {
     return (
-        <BooksEmptyStyle>
-            <div className="icon">
-                <FaSmileWink />
-            </div>
-            <Title size="large" color="secondary">
-                검색 결과가 없습니다.
-            </Title>
-            <p>
-                <Link to="/books">전체 검색 결과로 이동</Link>
-            </p>
-        </BooksEmptyStyle>
+        <Empty
+            title="검색 결과가 없습니다."
+            icon={<FaSmileWink />}
+            description={<Link to="/books">전체 검색 결과로 이동</Link>}
+        />
     );
 }
-
-const BooksEmptyStyle = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-    padding: 120px 0;
-
-    .icon {
-        svg {
-            font-size: 4rem;
-            fill: #ccc;
-        }
-    }
-`;
 
 export default BooksEmpty;

--- a/src/components/cart/CartItem.tsx
+++ b/src/components/cart/CartItem.tsx
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import { Cart } from '../../models/cart.model';
+import Button from '../common/Button';
+import Title from '../common/Title';
+import { formatNumber } from '../../utils/format';
+import CheckIconButton from './CheckIconButton';
+import { useMemo } from 'react';
+import { useAlert } from '../../hooks/useAlert';
+
+interface Props {
+    cart: Cart;
+    checkedItems: number[];
+    onCheck: (id: number) => void;
+    onDelete: (id: number) => void;
+}
+
+function CartItem({ cart, checkedItems, onCheck, onDelete }: Props) {
+    const { showConfirm } = useAlert();
+
+    const isChecked = useMemo(() => {
+        return checkedItems.includes(cart.itemId);
+    }, [checkedItems, cart.itemId]);
+
+    const handleCheck = () => {
+        onCheck(cart.itemId);
+    };
+
+    const handleDelete = () => {
+        showConfirm("정말 삭제하시겠습니까?", () => {
+            onDelete(cart.itemId);
+        });
+    };
+
+    return (
+        <CartItemStyle>
+            <div className="info">
+                <div className="check">
+                    <CheckIconButton onCheck={handleCheck} isChecked={isChecked} />
+                </div>
+                <div>
+                    <Title size="medium" color="text">{cart.title}</Title>
+                    <p className="summary">{cart.summary}</p>
+                    <p className="price">{formatNumber(cart.price)} 원</p>
+                    <p className="quantity">{cart.quantity} 권</p>
+                </div>
+            </div>
+            <Button size="medium" scheme="normal" onClick={handleDelete}>장바구니 삭제</Button>
+        </CartItemStyle>
+    );
+}
+
+const CartItemStyle = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: start;
+    border: 1px solid ${({ theme }) => theme.color.border};
+    border-radius: ${({ theme }) => theme.borderRadius.default};
+    padding: 12px;
+
+    .info {
+        display: flex;
+        align-items: start;
+        flex: 1;
+
+        .check {
+            width: 40px;
+            flex-shrink: 0;
+        }
+        
+        p {
+            padding: 0 0 8px 0;
+            margin: 0;
+        }
+    }
+
+    `;
+
+export default CartItem;

--- a/src/components/cart/CartSummary.tsx
+++ b/src/components/cart/CartSummary.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { formatNumber } from '../../utils/format';
+import Title from '../common/Title';
+
+interface Props {
+    totalQuantity: number;
+    totalPrice: number;
+}
+
+function CartSummary({ totalQuantity, totalPrice }: Props) {
+    return (
+        <CartSummaryStyle>
+            <Title size="medium" color="text">주문 요약</Title>
+            <dl>
+                <dt>총 수량</dt>
+                <dd>{totalQuantity} 권</dd>
+            </dl>
+            <dl>
+                <dt>총 금액</dt>
+                <dd>{formatNumber(totalPrice)} 원</dd>
+            </dl>
+        </CartSummaryStyle>
+    );
+}
+
+const CartSummaryStyle = styled.div`
+    border: 1px solid ${({ theme }) => theme.color.border};
+    border-radius: ${({ theme }) => theme.borderRadius.default};
+    padding: 12px;
+    width: 240px;
+
+    dl {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 12px;
+        dd {
+            font-weight: 700;
+        }
+    }
+`;
+
+export default CartSummary;

--- a/src/components/cart/CheckIconButton.tsx
+++ b/src/components/cart/CheckIconButton.tsx
@@ -1,0 +1,30 @@
+import { FaRegCircle, FaRegCheckCircle } from 'react-icons/fa';
+import styled from 'styled-components';
+
+interface Props {
+    isChecked: boolean;
+    onCheck: () => void;
+}
+
+function CheckIconButton({ isChecked, onCheck }: Props) {
+    return (
+        <CheckIconButtonStyle onClick={onCheck}>
+            {
+                isChecked ? <FaRegCheckCircle /> : <FaRegCircle />
+            }
+        </CheckIconButtonStyle>
+    );
+}
+
+const CheckIconButtonStyle = styled.button`
+    background: none;
+    border: 0;
+    cursor: pointer;
+
+    svg {
+        width: 24px;
+        height: 24px;
+    }
+`;
+
+export default CheckIconButton;

--- a/src/components/common/Empty.tsx
+++ b/src/components/common/Empty.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import Title from './Title';
+
+interface Props {
+    icon?: React.ReactNode;
+    title: string;
+    description?: React.ReactNode;
+}
+
+function Empty({ icon, title, description }: Props) {
+    return (
+        <EmptyStyle>
+            {icon && <div className="icon">{icon}</div>}
+            <Title size="large" color="secondary">
+                {title}
+            </Title>
+            {description && <p>{description}</p>}
+        </EmptyStyle>
+    );
+}
+
+const EmptyStyle = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    padding: 120px 0;
+
+    .icon {
+        svg {
+            font-size: 4rem;
+            fill: #ccc;
+        }
+    }
+`;
+
+export default Empty;

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -5,5 +5,11 @@ export const useAlert = () => {
         window.alert(message);
     }, []);
 
-    return showAlert;
+    const showConfirm = useCallback((message: string, onConfirm: () => void) => {
+        if (window.confirm(message)) {
+            onConfirm();
+        }
+    }, []);
+
+    return { showAlert, showConfirm };
 };

--- a/src/hooks/useBook.ts
+++ b/src/hooks/useBook.ts
@@ -10,7 +10,7 @@ export const useBook = (bookId: string | undefined) => {
     const [cartAdded, setCartAdded] = useState(false);
 
     const { isLoggedIn } = useAuthStore();
-    const showAlert = useAlert();
+    const { showAlert } = useAlert();
 
     const likeToggle = () => {
         if (!isLoggedIn) {

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { Cart } from "../models/cart.model";
+import { deleteCart, fetchCart } from "../api/carts.api";
+
+export const useCart = () => {
+    const [carts, setCarts] = useState<Cart[]>([]);
+    const [isEmpty, setIsEmpty] = useState(true);
+
+    const deleteCartItem = (itemId: number) => {
+        deleteCart(itemId)
+            .then(() => {
+                setCarts(carts.filter((cart) => cart.itemId !== itemId))
+            });
+    };
+
+    useEffect(() => {
+        fetchCart()
+            .then((carts) => {
+                setCarts(carts);
+            });
+    }, []);
+
+    useEffect(() => {
+        setIsEmpty(carts.length === 0);
+    }, [carts]);
+
+    return { carts, isEmpty, deleteCartItem };
+};

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -8,3 +8,15 @@ export interface Order {
     totalQuantity: number;
     totalPrice: number;
 }
+
+export interface OrderSheet {
+    items: number[],
+    delivery: {
+        address: string;
+        recipient: string;
+        contact: string;
+    },
+    totalPrice: number;
+    totalQuantity: number;
+    firstBookTitle: string;
+}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,0 +1,127 @@
+import styled from 'styled-components';
+import Title from '../components/common/Title';
+import CartItem from '../components/cart/CartItem';
+import { useCart } from '../hooks/useCart';
+import { useMemo, useState } from 'react';
+import Empty from '../components/common/Empty';
+import { FaShoppingCart } from 'react-icons/fa';
+import CartSummary from '../components/cart/CartSummary';
+import Button from '../components/common/Button';
+import { useAlert } from '../hooks/useAlert';
+import { OrderSheet } from '../models/order.model';
+import { useNavigate } from 'react-router-dom';
+
+function Cart() {
+    const { showAlert, showConfirm } = useAlert();
+    const navigate = useNavigate();
+
+    const { carts, isEmpty, deleteCartItem } = useCart();
+    const [checkedItems, setCheckedItems] = useState<number[]>([]);
+
+    const handleCheckItem = (itemId: number) => {
+        if (checkedItems.includes(itemId)) {
+            setCheckedItems(checkedItems.filter((id) => id !== itemId));
+        } else {
+            setCheckedItems([...checkedItems, itemId]);
+        }
+    };
+
+    const handleDeleteItem = (itemId: number) => {
+        deleteCartItem(itemId);
+    };
+
+    const totalQuantity = useMemo(() => {
+        return carts.reduce((acc, cart) =>
+            checkedItems.includes(cart.itemId)
+                ? acc + cart.quantity
+                : acc, 0);
+    }, [carts, checkedItems]);
+
+    const totalPrice = useMemo(() => {
+        return carts.reduce((acc, cart) =>
+            checkedItems.includes(cart.itemId)
+                ? acc + cart.price * cart.quantity
+                : acc, 0);
+    }, [carts, checkedItems]);
+
+    const handleOrder = () => {
+        if (checkedItems.length === 0) {
+            showAlert("주문할 상품을 선택해 주세요.");
+            return;
+        }
+
+        const selectedCarts = carts.filter((cart) => checkedItems.includes(cart.itemId));
+        const orderData: Omit<OrderSheet, "delivery"> = {
+            items: checkedItems,
+            totalPrice,
+            totalQuantity,
+            firstBookTitle: selectedCarts[0].title,
+        };
+
+        showConfirm("주문하시겠습니까?", () => {
+            navigate("/order", { state: orderData });
+        });
+    };
+
+    return (
+        <>
+            <Title size="large">장바구니</Title>
+            <CartStyle>
+                {
+                    !isEmpty && (
+                        <>
+                            <div className="content">
+                                {
+                                    carts.map((cart) => (
+                                        <CartItem
+                                            key={cart.itemId}
+                                            cart={cart}
+                                            checkedItems={checkedItems}
+                                            onCheck={handleCheckItem}
+                                            onDelete={handleDeleteItem} />
+                                    ))
+                                }
+                            </div>
+                            <div className="summary">
+                                <CartSummary totalQuantity={totalQuantity} totalPrice={totalPrice} />
+                                <Button size="large" scheme="primary" onClick={handleOrder}>주문하기</Button>
+                            </div>
+                        </>
+                    )
+                }
+                {
+                    isEmpty && (
+                        <Empty
+                            title="장바구니가 비었습니다."
+                            icon={<FaShoppingCart />}
+                            description={<>장바구니를 채워보세요.</>}
+                        />
+                    )
+                }
+            </CartStyle>
+        </>
+    );
+}
+
+const CartStyle = styled.div`
+    display: flex;
+    gap: 24px;
+    justify-content: space-between;
+    padding: 24px 0 0 0;
+
+    .content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .summary {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+`;
+
+export default Cart;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,7 @@ export interface SignupProps {
 
 function Login() {
     const navigate = useNavigate();
-    const showAlert = useAlert();
+    const { showAlert } = useAlert();
 
     const { storeLogin } = useAuthStore();
 

--- a/src/pages/Order.tsx
+++ b/src/pages/Order.tsx
@@ -1,0 +1,19 @@
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+
+function Order() {
+    const location = useLocation();
+    const orderDataFromCart = location.state;
+
+    console.log(orderDataFromCart);
+
+    return (
+        <OrderStyle>
+            <h1>Order</h1>
+        </OrderStyle>
+    );
+}
+
+const OrderStyle = styled.div``;
+
+export default Order;

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -15,9 +15,9 @@ export interface SignupProps {
 
 function ResetPassword() {
     const navigate = useNavigate();
-    const showAlert = useAlert();
+    const { showAlert } = useAlert();
     const [resetRequested, setResetRequested] = useState(false);
-    
+
     const {
         register,
         handleSubmit,

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -14,7 +14,7 @@ export interface SignupProps {
 
 function Signup() {
     const navigate = useNavigate();
-    const showAlert = useAlert();
+    const { showAlert } = useAlert();
 
     const {
         register,
@@ -35,11 +35,11 @@ function Signup() {
             <SignupStyle>
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <fieldset>
-                        <InputText placeholder="이메일" inputType="email" {...register("email", {required: true})} />
+                        <InputText placeholder="이메일" inputType="email" {...register("email", { required: true })} />
                         {errors.email && <p className="error-text">이메일을 입력해주세요.</p>}
                     </fieldset>
                     <fieldset>
-                        <InputText placeholder="비밀번호" inputType="password" {...register("password", {required: true})} />
+                        <InputText placeholder="비밀번호" inputType="password" {...register("password", { required: true })} />
                         {errors.password && <p className="error-text">비밀번호를 입력해주세요.</p>}
                     </fieldset>
                     <fieldset>


### PR DESCRIPTION
# 장바구니 페이지
1. 사용자가 장바구니에 담은 내역 확인
2. 선택한 도서 아이템의 수량과 가격 합계 표시
3. 장바구니에 담은 도서 아이템 삭제
4. 각 도서 아이템을 선택하여 주문서 작성

# 개인적인 추가 작업
1. `useCart.ts`
   기존에는 처음 mount 시에만  `isEmpty` 값이 업데이트가 되기 때문에 사용자가 장바구니를 모두 비워도 Empty component가 화면에 render되지 않는 문제가 발생
   → [`carts` 배열이 변경될 때마다 `isEmpty`가 업데이트되도록 코드를 추가](https://github.com/do0ori/book-store-project-FE/pull/3/commits/e53b082d511585653ed760b826f442ab6468891d#diff-32f5263f6923662702bdacb0459f2505addfc6aa14239227d6e11cf98d18fac5R23-R25)
2. `Cart.tsx`
    강의에서 `handleOrder` 함수에서 order 페이지로 전달할 `orderData` 객체를 생성할 때 `firstBookTitle` field에 carts의 첫번째 요소의 title(`carts[0].title`)을 사용
    → [하지만 `firstBookTitle`은 선택한 carts 요소들 중 첫번째 item의 title을 의미하기 때문에 잘못되었으므로 이에 맞게 수정](https://github.com/do0ori/book-store-project-FE/pull/3/commits/e53b082d511585653ed760b826f442ab6468891d#diff-644355d2b363aca2e7777863f494aabf08daaa788ceb0dc6fd27790b48a888aaR58)