### PR TITLE
주문 페이지

### DIFF
--- a/src/api/order.api.ts
+++ b/src/api/order.api.ts
@@ -1,0 +1,7 @@
+import { OrderSheet } from "../models/order.model";
+import { httpClient } from "./http";
+
+export const order = async (orderData: OrderSheet) => {
+    const response = await httpClient.post("/orders", orderData);
+    return response.data;
+};

--- a/src/components/cart/CartSummary.tsx
+++ b/src/components/cart/CartSummary.tsx
@@ -29,6 +29,10 @@ const CartSummaryStyle = styled.div`
     padding: 12px;
     width: 240px;
 
+    h1 {
+        padding: 0 0 24px 0;
+    }
+
     dl {
         display: flex;
         justify-content: space-between;

--- a/src/components/order/FindAddressButton.tsx
+++ b/src/components/order/FindAddressButton.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import Button from '../common/Button';
+
+interface Props {
+    onCompleted: (address: string) => void;
+}
+
+const SCRIPT_URL = "//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js";
+
+function FindAddressButton({ onCompleted }: Props) {
+    const handleOpen = () => {
+        new window.daum.Postcode({
+            oncomplete: (data: any) => {
+                onCompleted(data.address);
+            }
+        }).open();
+    };
+
+    useEffect(() => {
+        const script = document.createElement("script");
+        script.src = SCRIPT_URL;
+        script.async = true;
+        document.head.appendChild(script);
+
+        return () => {
+            document.head.removeChild(script);
+        };
+    }, []);
+
+    return (
+        <Button type="button" size="medium" scheme="normal" onClick={handleOpen}>주소 찾기</Button>
+    );
+}
+
+export default FindAddressButton;

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -10,13 +10,19 @@ export interface Order {
 }
 
 export interface OrderSheet {
-    items: number[],
-    delivery: {
-        address: string;
-        recipient: string;
-        contact: string;
-    },
+    items: {
+        cartItemId: number;
+        bookId: number;
+        quantity: number;
+    }[],
+    delivery: Delivery,
     totalPrice: number;
     totalQuantity: number;
     firstBookTitle: string;
+}
+
+export interface Delivery {
+    address: string;
+    recipient: string;
+    contact: string;
 }

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -51,8 +51,13 @@ function Cart() {
         }
 
         const selectedCarts = carts.filter((cart) => checkedItems.includes(cart.itemId));
+        const items = selectedCarts.map((cart) => ({
+            cartItemId: cart.itemId,
+            bookId: cart.bookId,
+            quantity: cart.quantity
+        }));
         const orderData: Omit<OrderSheet, "delivery"> = {
-            items: checkedItems,
+            items,
             totalPrice,
             totalQuantity,
             firstBookTitle: selectedCarts[0].title,
@@ -103,7 +108,7 @@ function Cart() {
     );
 }
 
-const CartStyle = styled.div`
+export const CartStyle = styled.div`
     display: flex;
     gap: 24px;
     justify-content: space-between;
@@ -122,6 +127,45 @@ const CartStyle = styled.div`
         gap: 24px;
     }
 
+    .order-info {
+        h1 {
+            padding: 0 0 24px 0;
+        }
+
+        border: 1px solid ${({ theme }) => theme.color.border};
+        border-radius: ${({ theme }) => theme.borderRadius.default};
+        padding: 12px;
+    }
+
+    .delivery {
+        fieldset {
+            border: 0;
+            margin: 0;
+            padding: 0 0 12px 0;
+            display: flex;
+            justify-content: start;
+            gap: 8px;
+    
+            label {
+                width: 80px;
+            }
+    
+            .input {
+                flex: 1;
+    
+                input {
+                    width: 100%;
+                }
+            }
+        }
+
+        .error-text {
+            color: red;
+            margin: 0;
+            padding: 0 0 12px 0;
+            text-align: right;
+        }
+    }
 `;
 
 export default Cart;

--- a/src/pages/Order.tsx
+++ b/src/pages/Order.tsx
@@ -1,19 +1,104 @@
-import { useLocation } from 'react-router-dom';
-import styled from 'styled-components';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Title from '../components/common/Title';
+import { CartStyle } from './Cart';
+import CartSummary from '../components/cart/CartSummary';
+import Button from '../components/common/Button';
+import InputText from '../components/common/InputText';
+import { useForm } from 'react-hook-form';
+import { Delivery, OrderSheet } from '../models/order.model';
+import FindAddressButton from '../components/order/FindAddressButton';
+import { order } from '../api/order.api';
+import { useAlert } from '../hooks/useAlert';
 
-function Order() {
-    const location = useLocation();
-    const orderDataFromCart = location.state;
-
-    console.log(orderDataFromCart);
-
-    return (
-        <OrderStyle>
-            <h1>Order</h1>
-        </OrderStyle>
-    );
+interface DeliveryForm extends Delivery {
+    addressDetail: string;
 }
 
-const OrderStyle = styled.div``;
+function Order() {
+    const { showAlert, showConfirm } = useAlert();
+    const location = useLocation();
+    const navigate = useNavigate();
+    const orderDataFromCart = location.state;
+    const { totalQuantity, totalPrice, firstBookTitle } = orderDataFromCart;
+
+    const {
+        register,
+        handleSubmit,
+        setValue,
+        formState: { errors }
+    } = useForm<DeliveryForm>();
+
+    const handlePay = (data: DeliveryForm) => {
+        const orderData: OrderSheet = {
+            ...orderDataFromCart,
+            delivery: {
+                address: `${data.address} ${data.addressDetail}`,
+                recipient: data.recipient,
+                contact: data.contact
+            }
+        };
+
+        showConfirm("주문을 진행하시겠습니까?", () => {
+            order(orderData)
+                .then(() => {
+                    showAlert("주문이 처리되었습니다.");
+                    navigate("/orderlist");
+                });
+        });
+
+    };
+
+    return (
+        <>
+            <Title size="large">주문서 작성</Title>
+            <CartStyle>
+                <div className="content">
+                    <div className="order-info">
+                        <Title size="medium" color="text">배송 정보</Title>
+                        <form className="delivery">
+                            <fieldset>
+                                <label>주소</label>
+                                <div className="input">
+                                    <InputText inputType="text" {...register("address", { required: true })} />
+                                </div>
+                                <FindAddressButton onCompleted={(address) => setValue("address", address)} />
+                            </fieldset>
+                            {errors.address && <p className="error-text">주소를 입력해주세요.</p>}
+                            <fieldset>
+                                <label>상세 주소</label>
+                                <div className="input">
+                                    <InputText inputType="text" {...register("addressDetail", { required: true })} />
+                                </div>
+                            </fieldset>
+                            {errors.addressDetail && <p className="error-text">상세 주소를 입력해주세요.</p>}
+                            <fieldset>
+                                <label>수령인</label>
+                                <div className="input">
+                                    <InputText inputType="text" {...register("recipient", { required: true })} />
+                                </div>
+                            </fieldset>
+                            {errors.recipient && <p className="error-text">수령인을 입력해주세요.</p>}
+                            <fieldset>
+                                <label>전화번호</label>
+                                <div className="input">
+                                    <InputText inputType="text" {...register("contact", { required: true })} />
+                                </div>
+                            </fieldset>
+                            {errors.contact && <p className="error-text">전화번호를 입력해주세요.</p>}
+                        </form>
+                    </div>
+                    <div className="order-info">
+                        <Title size="medium" color="text">주문 상품</Title>
+                        <strong>{firstBookTitle} 등 총 {totalQuantity} 권</strong>
+                    </div>
+                </div>
+                <div className="summary">
+                    <CartSummary totalQuantity={totalQuantity} totalPrice={totalPrice} />
+                    <Button size="large" scheme="primary" onClick={handleSubmit(handlePay)}>결제하기</Button>
+                </div>
+            </CartStyle>
+        </>
+    );
+}
 
 export default Order;

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+    daum: {
+        Postcode: any;
+    }
+}


### PR DESCRIPTION
# 주문 페이지
1. 장바구니로부터 넘어온 정보를 화면에 표시 및 보존
2. 주소, 수령인, 전화번호 입력 및 검증
3. 데이터를 가공하여 서버에 전달

# 개인적인 추가 작업
1. `order.model.ts`
   [order API의 body 형식에 맞게 OrderSheet의 items field의 type 수정](https://github.com/do0ori/book-store-project-FE/pull/4/commits/4373ae97c2091cf0afcaa980f9981318c39db368#diff-ded663087849ea737ae41ad7e22b50236b6aece6ed9cb11e7d38ac04d778c2e5R13-R17)
2. `Cart.tsx`
    [장바구니 페이지에서 주문 페이지로 전달되는 orderData 객체의 items field를 바뀐 OrderSheet 형식에 맞게 수정](https://github.com/do0ori/book-store-project-FE/pull/4/commits/4373ae97c2091cf0afcaa980f9981318c39db368#diff-644355d2b363aca2e7777863f494aabf08daaa788ceb0dc6fd27790b48a888aaR54-R60)