### PR TITLE
주문 내역 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Books from "./pages/Books";
 import BookDetail from "./pages/BookDetail";
 import Cart from "./pages/Cart";
 import Order from "./pages/Order";
+import OrderList from "./pages/OrderList";
 
 const router = createBrowserRouter([
   {
@@ -44,6 +45,14 @@ const router = createBrowserRouter([
   {
     path: "/order",
     element: <Layout><Order /></Layout>
+  },
+  {
+    path: "/order",
+    element: <Layout><Order /></Layout>
+  },
+  {
+    path: "/orderlist",
+    element: <Layout><OrderList /></Layout>
   },
 ]);
 

--- a/src/api/order.api.ts
+++ b/src/api/order.api.ts
@@ -1,7 +1,17 @@
-import { OrderSheet } from "../models/order.model";
+import { Order, OrderDetailItem, OrderSheet } from "../models/order.model";
 import { httpClient } from "./http";
 
 export const order = async (orderData: OrderSheet) => {
     const response = await httpClient.post("/orders", orderData);
+    return response.data;
+};
+
+export const fetchOrders = async () => {
+    const response = await httpClient.get<Order[]>("/orders");
+    return response.data;
+};
+
+export const fetchOrder = async (orderId: number) => {
+    const response = await httpClient.get<OrderDetailItem[]>(`/orders/${orderId}`);
     return response.data;
 };

--- a/src/components/books/Pagination.tsx
+++ b/src/components/books/Pagination.tsx
@@ -27,9 +27,8 @@ function Pagination({ pagination }: Props) {
                     <ol>
                         {
                             Array(pages).fill(0).map((_, i) => (
-                                <li>
+                                <li key={i}>
                                     <Button
-                                        key={i}
                                         size="small"
                                         scheme={i + 1 === currentPage ? "primary" : "normal"}
                                         onClick={() => handleClickPage(i + 1)}>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -22,7 +22,7 @@ function Header() {
                     {
                         category.map((item) => (
                             <li key={item.id}>
-                                <Link to={item.id === null ? '/books' : `/books?category_id=${item.id}`}>
+                                <Link to={item.id === null ? '/books?view=grid' : `/books?view=grid&category_id=${item.id}`}>
                                     {item.name}
                                 </Link>
                             </li>

--- a/src/hooks/useCategory.ts
+++ b/src/hooks/useCategory.ts
@@ -24,7 +24,7 @@ export const useCategory = () => {
 
     useEffect(() => {
         fetchCategory()
-            .then(category => {
+            .then((category) => {
                 if (!category) return;
 
                 const categoryWithAll = [

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { OrderListItem } from "../models/order.model";
+import { fetchOrder, fetchOrders } from "../api/order.api";
+
+export const useOrders = () => {
+    const [orders, setOrders] = useState<OrderListItem[]>([]);
+    const [selectedItemId, setSelectedItemId] = useState<number | null>(null);
+
+    useEffect(() => {
+        fetchOrders()
+            .then((orders) => {
+                setOrders(orders);
+            });
+    }, []);
+
+    const selectOrderItem = (orderId: number) => {
+        if (orders.filter((item) => item.orderId === orderId)[0].detail) {
+            if (selectedItemId === orderId) {
+                setSelectedItemId((prev) => prev === null ? orderId : null);
+            } else {
+                setSelectedItemId(orderId);
+            }
+            return;
+        }
+
+        fetchOrder(orderId)
+            .then((orderDetail) => {
+                setSelectedItemId(orderId);
+                setOrders(orders.map((item) => {
+                    if (item.orderId === orderId) {
+                        return {
+                            ...item,
+                            detail: orderDetail
+                        }
+                    }
+                    return item;
+                }));
+            });
+    };
+
+    return { orders, selectedItemId, selectOrderItem };
+};

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -9,6 +9,18 @@ export interface Order {
     totalPrice: number;
 }
 
+export interface OrderDetailItem {
+    bookId: number;
+    title: string;
+    author: string;
+    price: number;
+    quantity: number;
+}
+
+export interface OrderListItem extends Order {
+    detail?: OrderDetailItem[];
+}
+
 export interface OrderSheet {
     items: {
         cartItemId: number;

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -1,0 +1,122 @@
+import styled from 'styled-components';
+import Title from '../components/common/Title';
+import { useOrders } from '../hooks/useOrders';
+import { formatDate, formatNumber } from '../utils/format';
+import Button from '../components/common/Button';
+import React from 'react';
+
+function OrderList() {
+    const { orders, selectedItemId, selectOrderItem } = useOrders();
+
+    return (
+        <>
+            <Title size="large">주문 내역</Title>
+            <OrderListStyle>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>id</th>
+                            <th>주문 일자</th>
+                            <th>주소</th>
+                            <th>수령인</th>
+                            <th>전화번호</th>
+                            <th>대표 상품명</th>
+                            <th>수량</th>
+                            <th>금액</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {
+                            orders.map((order) => (
+                                <React.Fragment key={order.orderId}>
+                                    <tr>
+                                        <td>{order.orderId}</td>
+                                        <td>{formatDate(order.orderedAt, "YYYY.MM.DD")}</td>
+                                        <td>{order.address}</td>
+                                        <td>{order.recipient}</td>
+                                        <td>{order.contact}</td>
+                                        <td>{order.bookTitle}</td>
+                                        <td>{order.totalQuantity} 권</td>
+                                        <td>{formatNumber(order.totalPrice)} 원</td>
+                                        <td>
+                                            <Button
+                                                size="small"
+                                                scheme="normal"
+                                                onClick={() => selectOrderItem(order.orderId)}>
+                                                자세히
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                    {
+                                        selectedItemId === order.orderId && (
+                                            <tr>
+                                                <td></td>
+                                                <td colSpan={8}>
+                                                    <ul className="detail">
+                                                        {
+                                                            order.detail?.map((item) => (
+                                                                <li key={item.bookId}>
+                                                                    <div>
+                                                                        <span>
+                                                                            『{item.title}』
+                                                                        </span>
+                                                                        <span>
+                                                                            {item.author}
+                                                                        </span>
+                                                                        <span>
+                                                                            {formatNumber(item.price)} 원
+                                                                        </span>
+                                                                        <span>
+                                                                            {item.quantity} 권
+                                                                        </span>
+                                                                    </div>
+                                                                </li>
+                                                            ))
+                                                        }
+                                                    </ul>
+                                                </td>
+                                            </tr>
+                                        )
+                                    }
+                                </React.Fragment>
+                            ))
+                        }
+                    </tbody>
+                </table>
+            </OrderListStyle>
+        </>
+    );
+}
+
+const OrderListStyle = styled.div`
+    padding: 24px 0 0 0;
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        border-top: 1px solid ${({ theme }) => theme.color.border};
+        border-bottom: 1px solid ${({ theme }) => theme.color.border};
+
+        th, td {
+            padding: 16px 10px;
+            border-bottom: 1px solid ${({ theme }) => theme.color.border};
+            text-align: center;
+        }
+
+        .detail {
+            margin: 0;
+            li {
+                list-style: square;
+                text-align: left;
+                div {
+                    display: flex;
+                    padding: 8px 12px;
+                    gap: 8px;
+                }
+            }
+        }
+    }
+`;
+
+export default OrderList;


### PR DESCRIPTION
# 주문 페이지
1. 저장된 주문 내역을 목록(table)으로 표시
2. [자세히] 버튼으로 상세 정보 패널을 토글

# 개인적인 추가 작업
1. `useOrders.ts`
   [`selectOrderItem`에서 선택된 주문에 `detail` field가 있을 때 토글 기능 추가](https://github.com/do0ori/book-store-project-FE/pull/5/commits/b3e86922632a022bb642995fe9a11d7d298bd6ad#diff-020d66605cb6a0cd8388416faab6764cac3d5b713f7caea76b62229f4e70e8f7R18-R22)