### PR TITLE
무한 스크롤

### DIFF
--- a/src/hooks/useBooksInfinite.ts
+++ b/src/hooks/useBooksInfinite.ts
@@ -1,0 +1,48 @@
+import { useLocation } from "react-router-dom";
+import { QUERYSTRING } from "../constants/querystrings";
+import { fetchBooks } from "../api/books.api";
+import { LIMIT } from "../constants/pagination";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export const useBooksInfinite = () => {
+    const location = useLocation();
+
+    const getBooks = ({ pageParam }: { pageParam: number }) => {
+        const params = new URLSearchParams(location.search);
+        const categoryId = params.get(QUERYSTRING.CATEGORY_ID) ? Number(params.get(QUERYSTRING.CATEGORY_ID)) : undefined;
+        const recent = params.get(QUERYSTRING.RECENT) ? true : undefined;
+        const limit = LIMIT;
+        const page = pageParam;
+
+        return fetchBooks({
+            categoryId,
+            recent,
+            limit,
+            page
+        });
+    };
+
+    const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
+        queryKey: ["books", location.search],
+        queryFn: getBooks,
+        initialPageParam: 1,
+        getNextPageParam: (lastPage) => {
+            const isLastPage = Math.ceil(lastPage.pagination.totalCount / LIMIT) === lastPage.pagination.currentPage;
+
+            return isLastPage ? null : lastPage.pagination.currentPage + 1;
+        }
+    });
+
+    const books = data ? data.pages.flatMap((page) => page.books) : [];
+    const pagination = data ? data.pages[data.pages.length - 1].pagination : {};
+    const isEmpty = books.length === 0;
+
+    return {
+        books,
+        pagination,
+        isEmpty,
+        isBooksLoading: isFetching,
+        fetchNextPage,
+        hasNextPage
+    };
+};

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+
+type Callback = (entries: IntersectionObserverEntry[]) => void;
+
+interface ObserverOptions {
+    root?: Element | null;
+    rootMargin?: string;
+    threshold?: number | number[];
+}
+
+export const useIntersectionObserver = (callback: Callback, options?: ObserverOptions) => {
+    const targetRef = useRef(null);
+
+    useEffect(() => {
+        const intersectionObserver = new IntersectionObserver(callback, options);
+
+        if (targetRef.current) {
+            intersectionObserver.observe(targetRef.current);
+        }
+
+        return () => {
+            if (targetRef.current) {
+                intersectionObserver.unobserve(targetRef.current);
+            }
+        };
+    });
+
+    return targetRef;
+};

--- a/src/pages/Books.tsx
+++ b/src/pages/Books.tsx
@@ -7,9 +7,24 @@ import Pagination from '../components/books/Pagination';
 import BooksViewSwitcher from '../components/books/BooksViewSwitcher';
 import { useBooks } from '../hooks/useBooks';
 import Loading from '@/components/common/Loading';
+import { useBooksInfinite } from '@/hooks/useBooksInfinite';
+import Button from '@/components/common/Button';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 
 function Books() {
-    const { books, pagination, isEmpty, isBooksLoading } = useBooks();
+    // const { books, pagination, isEmpty, isBooksLoading } = useBooks();
+    const { books, pagination, isEmpty, isBooksLoading, fetchNextPage, hasNextPage } = useBooksInfinite();
+
+    const moreRef = useIntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+            loadMore();
+        }
+    });
+
+    const loadMore = () => {
+        if (!hasNextPage) return;
+        fetchNextPage();
+    };
 
     if (isEmpty) {
         return <BooksEmpty />;
@@ -28,7 +43,13 @@ function Books() {
                     <BooksViewSwitcher />
                 </div>
                 <BooksList books={books} />
-                <Pagination pagination={pagination} />
+                {/* <Pagination pagination={pagination} /> */}
+
+                <div className="more" ref={moreRef}>
+                    <Button size="medium" scheme="normal" onClick={() => fetchNextPage()} disabled={!hasNextPage}>
+                        {hasNextPage ? "더보기" : "마지막 페이지"}
+                    </Button>
+                </div>
             </BooksStyle>
         </>
     );


### PR DESCRIPTION
# 무한 스크롤(Infinite Scroll)
- React Query의 `useInfiniteQuery` hook을 기반으로 책 data를 가져오는 `useBooksInfinite`라는 custom hook 생성
-  스크롤을 했을 때 책 data를 가져오기 위해 `intersectionObserver` API를 기반으로 `useIntersectionObserver`라는 custom hook 생성
- `Books.tsx`에 custom hook들을 적용해 무한 스크롤 적용

# 개인적인 추가 작업
- 무한 스크롤 시 스크롤 위치가 맨 위로 초기화되는 문제 해결 (https://github.com/do0ori/book-store-project-FE/commit/9063403a5535b79efc4e1a55d7c1fc8934cc4a5d)
    - `useBooksInfinite.ts`에서 fetch 작업 전에 스크롤 위치를 저장하고, 스크롤 위치를 반환
    - `Books.tsx`에서 `useEffect`로 `books` 배열(`isBooksLoading`도 가능)이 바뀔 때 (fetch 후에) hook에서 반환한 스크롤 위치로 이동하도록 해서 이전 스크롤 위치 유지
- 스크롤 위치를 직접 복원하는 방법은 근본적인 해결책이 아니었음 (https://github.com/do0ori/book-store-project-FE/commit/75812cdf7f694e0ed9765c4592009e79e88d1684)
    - early return에 의한 현상이었고 해당 부분을 수정함으로써 문제를 해결
    - [기본적으로 chrome 브라우저 자체에서 History API를 활용해 스크롤 위치를 복원해주는 기능을 제공함](https://developer.chrome.com/blog/history-api-scroll-restoration)